### PR TITLE
Fix nix build on latest nixos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     pkgsForEach = nixpkgs.legacyPackages;
   in {
     packages = forAllSystems (system: {
-      default = pkgsForEach.${system}.python311Packages.callPackage ./nix/default.nix {};
+      default = pkgsForEach.${system}.callPackage ./nix/default.nix {};
     });
 
     devShells = forAllSystems (system: {


### PR DESCRIPTION
On nixos unstable using `python311Packages` as input in a package called with `python311Packages.callPackage` is not admitted anymore. With `python311Packages.callPackage` every python package should be an argument, so using `python311Packages.callPackage` or `python312Packages.callPackage` can change all the packages versions, but this is not the case. 