### PR TITLE
Fix build in latest nixpkgs

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -14,7 +14,7 @@ let
     pyasyncore
     pywayland
     xkbcommon
-    systemd
+    systemd-python
   ]);
 in
 python311Packages.buildPythonPackage {


### PR DESCRIPTION
`error: systemd was removed because it was misnamed; use systemd-python instead`