### PR TITLE
Fix Python 3.14 I2C support using python-periphery and i2ctransfer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ libevdev
 numpy
 pyinotify
 python-xlib
-smbus2
+python-periphery
 pyasyncore
 pywayland
 xkbcommon<1.1


### PR DESCRIPTION
This PR addresses the Python 3.14 I2C issues (previously causing SystemError("buffer overflow") with smbus2) by aligning asus-dialpad-driver with the approach used in asus-numberpad-driver.

Summary of changes

- requirements.txt
  - Remove `smbus2`
  - Add `python-periphery`

- dialpad.py
  - Replace `from smbus2 import SMBus, i2c_msg` with `from periphery import I2C`.
  - Update the initial I2C bus open check:
    - Try `I2C("/dev/i2c-<device_id>")` and close it on success.
    - If that fails, fall back to opening `/dev/i2c-<device_id>` directly (`open(path, "rb+", buffering=0)`).
    - If both fail, log a detailed error (`Can not open the I2C bus connection (id: %s) at %s: %s`) and exit.
  - Rewrite `send_value_to_touchpad_via_i2c`:
    1. Construct the same payload array as before.
    2. First attempt to send via python-periphery:
       - `with I2C(path) as i2c:`
       - `msg = I2C.Message(data)`
       - `i2c.transfer(device_addr, [msg])`
    3. On exception, fall back to the `i2ctransfer` binary (from i2c-tools):
       - `i2ctransfer -f -y <bus> w<len>@0x<addr> <data bytes...>`
    4. Add debug/error logging for both paths.
  - Remove all remaining references to `SMBus` and smbus2 (the library is no longer required).

Testing

- Hardware: Asus ProArt P16 (ASCP1A01:00 093A:3014 Touchpad)
- OS: Fedora 43, Wayland
- Python: 3.14.x (venv)

Results:

- The previous smbus2 `SystemError("buffer overflow")` on Python 3.14 no longer occurs.
- DialPad works normally:
  - Wayland session is detected.
  - Virtual uinput device is initialized successfully.
  - Touchpad and keyboard events are processed.
  - The top-right icon region is detected and toggles the DialPad OSD.
  - Dial controls system volume as expected.

Notes

On Fedora 43, I had to ensure that the user has permissions for:

- `/dev/i2c-0` via `i2c` group membership and `0660` mode,
- `/dev/uinput` via `uinput` group membership and `0660` mode.

This was handled via tmpfiles.d/udev rules on my system and is not part of this PR, as it is distro-specific.

PS. I can adjust names/log messages to match your style preferences, but functionally this brings DialPad in line with the numberpad driver and makes it work on Python 3.14.
