### PR TITLE
Make the Nix code more composable & decouple from flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ Run driver now and every time that user logs in (do NOT run as `$ sudo`, works v
 $ bash install_service.sh
 ```
 
-or for NixOS you can use flakes for the installation of this driver.
+#### NixOS
+
+Nix code is provided for this driver.
 
 > [!IMPORTANT]
 > In case the layout isn't provided, the "proartp16" DialPad layout is used.
@@ -198,7 +200,52 @@ or for NixOS you can use flakes for the installation of this driver.
 <summary>The driver installation (NixOS)</summary>
 <br>
 
-This repo contains a Flake that exposes a NixOS Module that manages and offers options for asus-dialpad-driver. To use it, add the flake as an input to your `flake.nix` file and enable the module:
+##### All Nix versions
+
+First, you will want to pin this repository using your input pinner of choice (some [listed on the Wiki](https://wiki.nixos.org/wiki/Applications#Dependencies)).
+After, we need to add the overlay & module to the system.
+While there are many ways to organize a NixOS system, for a simple `configuration.nix`-only example:
+
+```nix
+# configuration.nix
+{ config, lib, pkgs, ... }:
+
+let
+  inputs = import ./my/pinned/inputs { };
+in
+{
+  system = "x86_64-linux";
+
+  nixpkgs.overlays = [
+    (import "${inputs.asus-dialpad-driver}/nix/overlay")
+  ];
+
+  modules = [
+    (import "${inputs.asus-dialpad-driver}/nix/module.nix")
+  ];
+
+  # Enable Asus DialPad Service
+  services.asus-dialpad-driver = {
+    enable = true;
+    layout = "default";
+    wayland = true;
+    ignoreWaylandDisplayEnv = false;
+    runtimeDir = "/run/user/1000/";
+    waylandDisplay = "wayland-0";
+  };
+}
+```
+
+> The key for the caclulator toggling script should be associated with XF86Calculator, allowing it to toggle any calculator application, not just the one specified in the configuration. This means that the key binding can be used to manage various calculator applications across different key binding configurations. For e.g.:
+
+```nix
+"XF86Calculator".action = sh -c "if pidof gnome-calculator > /dev/null; then kill $(pidof gnome-calculator); else gnome-calculator; fi";
+```
+
+##### Nix flakes only
+
+[Flakes](https://nix.dev/concepts/flakes.html) are another, experimental way to add asus-dialpad-driver to your system.
+To add it to your system’s flake.
 
 ```nix
 # flake.nix
@@ -217,41 +264,23 @@ This repo contains a Flake that exposes a NixOS Module that manages and offers o
 
     outputs = {nixpkgs, asus-dialpad-driver, ...} @ inputs: {
         nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
-            specialArgs = { inherit inputs; };
+
             modules = [
-                ./configuration.nix
+                ({ ... }: {
+                  nixpkgs.overlays = [
+                    asus-dialpad-driver.overlays.default
+                  ];
+                })
                 asus-dialpad-driver.nixosModules.default
+                ./configuration.nix
             ];
         };
     }
 }
 ```
-Then you can enable the program in your `configuration.nix` file:
-```nix
-# configuration.nix
-
-{inputs, pkgs, ...}: {
-  # ---Snip---
-  # Enable Asus DialPad Service
-  services.asus-dialpad-driver = {
-    enable = true;
-    layout = "default";
-    wayland = true;
-    ignoreWaylandDisplayEnv = false;
-    runtimeDir = "/run/user/1000/";
-    waylandDisplay = "wayland-0";
-  };
-  # ---Snip---
-}
+Then you can enable the service, `services.asus-dialpad-driver`, in your `configuration.nix` file in the same way as the prior section for stable Nix.
 
 ```
-
-> The key for the caclulator toggling script should be associated with XF86Calculator, allowing it to toggle any calculator application, not just the one specified in the configuration. This means that the key binding can be used to manage various calculator applications across different key binding configurations. For e.g.:
-
-```
-"XF86Calculator".action = sh -c "if pidof gnome-calculator > /dev/null; then kill $(pidof gnome-calculator); else gnome-calculator; fi";
-```
-
 </details>
 
 ## Uninstallation

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,1 @@
+(import ./release.nix).default

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = {nixpkgs, self, ...} @ inputs: let
+  outputs = {nixpkgs, self, ...}: let
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "i686-linux" "aarch64-linux"];
 
     pkgsForEach = forAllSystems (system: nixpkgs.legacyPackages.${system}.appendOverlays [
@@ -27,6 +27,6 @@
       development = import ./nix/overlay/development.nix;
     };
 
-    nixosModules.default = import ./nix/module.nix inputs;
+    nixosModules.default = import ./nix/module.nix;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -7,14 +7,18 @@
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "i686-linux" "aarch64-linux"];
     pkgsForEach = nixpkgs.legacyPackages;
   in {
-    packages = forAllSystems (system: {
-      default = pkgsForEach.${system}.callPackage ./nix { python3Packages = pkgsForEach.${system}.python313Packages; };
-    });
+    packages = forAllSystems (system:
+      let pkgs = pkgsForEach.${system}; in
+      {
+        default = pkgs.callPackage ./nix {
+          xinput = pkgs.xinput or pkgs.xorg.xinput;
+        };
+      });
 
     devShells = forAllSystems (system: {
-      default = pkgsForEach.${system}.callPackage ./nix/shell.nix { 
+      default = pkgsForEach.${system}.callPackage ./nix/shell.nix {
         inherit self;
-        python3Packages = pkgsForEach.${system}.python313Packages; 
+        python3Packages = pkgsForEach.${system}.python313Packages;
       };
     });
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
 
     pkgsForEach = forAllSystems (system: nixpkgs.legacyPackages.${system}.appendOverlays [
       self.overlays.default
+      self.overlays.development
     ]);
   in {
     packages = forAllSystems (system:
@@ -18,14 +19,12 @@
       });
 
     devShells = forAllSystems (system: {
-      default = pkgsForEach.${system}.callPackage ./nix/shell.nix {
-        inherit self;
-        python3Packages = pkgsForEach.${system}.python313Packages;
-      };
+      default = pkgsForEach.${system}.asus-dialpad-driver-shell;
     });
 
     overlays = {
       default = import ./nix/overlay/default.nix;
+      development = import ./nix/overlay/development.nix;
     };
 
     nixosModules.default = import ./nix/module.nix inputs;

--- a/flake.nix
+++ b/flake.nix
@@ -5,14 +5,16 @@
 
   outputs = {nixpkgs, self, ...} @ inputs: let
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "i686-linux" "aarch64-linux"];
-    pkgsForEach = nixpkgs.legacyPackages;
+
+    pkgsForEach = forAllSystems (system: nixpkgs.legacyPackages.${system}.appendOverlays [
+      self.overlays.default
+    ]);
   in {
     packages = forAllSystems (system:
       let pkgs = pkgsForEach.${system}; in
       {
-        default = pkgs.callPackage ./nix {
-          xinput = pkgs.xinput or pkgs.xorg.xinput;
-        };
+        inherit (pkgs) asus-dialpad-driver;
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.asus-dialpad-driver;
       });
 
     devShells = forAllSystems (system: {
@@ -22,8 +24,8 @@
       };
     });
 
-    overlays.default = final: _: {
-      asus-dialpad-driver = self.packages.${final.stdenv.hostPlatform.system}.default;
+    overlays = {
+      default = import ./nix/overlay/default.nix;
     };
 
     nixosModules.default = import ./nix/module.nix inputs;

--- a/nix/compat.nix
+++ b/nix/compat.nix
@@ -1,9 +1,0 @@
-{ pkgs }:
-
-{
-  # test first if the new package name "xinput" is available, otherwise revert to the legacy package name "xorg.xinput".
-  xinput =
-    if pkgs ? xinput
-    then pkgs.xinput
-    else pkgs.xorg.xinput;
-}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -13,7 +13,17 @@
 python3Packages.buildPythonPackage {
   pname = "asus-dialpad-driver";
   version = "2.2.1";
-  src = ../.;
+
+  src =
+    let fs = lib.fileset; in
+    fs.toSource {
+      root = ../.;
+      fileset = fs.unions [
+        (fs.fileFilter (f: f.hasExt "py") ../.)
+        ../layouts
+        ../laptop_dialpad_layouts
+      ];
+    };
 
   pyproject = false;
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,27 +1,22 @@
 { lib
-, pkgs
 , python3Packages
 , ibus
 , libevdev
 , curl
-, xorg
+, xinput # xorg.xinput can passed in with override for old version of Nixpkgs
 , i2c-tools
 , libxml2
 , libxkbcommon
 , waylandSupport ? false
 }:
 
-let
-  compat = import ./compat.nix { inherit pkgs; };
-in
-
-python3Packages.buildPythonApplication {
+python3Packages.buildPythonPackage {
   pname = "asus-dialpad-driver";
   version = "2.2.1";
   src = ../.;
-  
+
   pyproject = false;
-  
+
   dependencies = with python3Packages; [
     numpy
     python3Packages.libevdev
@@ -32,13 +27,13 @@ python3Packages.buildPythonApplication {
     systemd-python
     xcffib
     python-periphery
-  ] ++ lib.optional waylandSupport [ python3Packages.pywayland ];
+  ] ++ lib.optional waylandSupport python3Packages.pywayland;
 
   buildInputs = [
     ibus
     libevdev
     curl
-    compat.xinput
+    xinput
     i2c-tools
     libxml2
     libxkbcommon
@@ -62,7 +57,7 @@ python3Packages.buildPythonApplication {
     # Change line endings to Unix format
     sed -i 's/\r$//' $out/share/asus-dialpad-driver/dialpad.py
   '';
-  
+
   # Patch shebangs (defaults to files in $out/bin)
   postFixup = ''
     wrapPythonProgramsIn "$out/share/asus-dialpad-driver" "$out $pythonPath"

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,5 +1,4 @@
-
-inputs: { config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 let
   cfg = config.services.asus-dialpad-driver;
@@ -9,14 +8,13 @@ let
     text = lib.generators.toINI {} cfg.config;
     destination = "/dialpad_dev";
   };
-  
 in {
   options.services.asus-dialpad-driver = {
     enable = lib.mkEnableOption "Enable the Asus DialPad Driver service.";
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.default.override { waylandSupport = cfg.wayland; };
+      default = pkgs.asus-dialpad-driver.override { waylandSupport = cfg.wayland; };
       description = "The package to use for the Asus DialPad Driver.";
     };
 
@@ -109,7 +107,7 @@ in {
     users.users.root.extraGroups = [ "i2c" "input" "uinput" ];
 
     # Add the udev rule to set permissions for uinput and i2c-dev
-    services.udev.extraRules = ''
+    services.udev.extraRules = /* udev */ ''
       # Set uinput device permissions
       KERNEL=="uinput", GROUP="uinput", MODE="0660"
       # Set i2c-dev permissions

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -8,6 +8,10 @@ let
     text = lib.generators.toINI {} cfg.config;
     destination = "/dialpad_dev";
   };
+
+  package =
+    cfg.package.override
+      (lib.optionalAttrs cfg.wayland { waylandSupport = true; });
 in {
   options.services.asus-dialpad-driver = {
     enable = lib.mkEnableOption "Enable the Asus DialPad Driver service.";
@@ -86,7 +90,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [ package ];
 
     # Ensure the writable directories exists
     systemd.tmpfiles.rules = [
@@ -124,13 +128,13 @@ in {
       startLimitIntervalSec=300;
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${cfg.package}/share/asus-dialpad-driver/dialpad.py ${cfg.layout} ${configFileDir}/";
+        ExecStart = "${package}/share/asus-dialpad-driver/dialpad.py ${cfg.layout} ${configFileDir}/";
         StandardOutput = null;
         StandardError = null;
         Restart = "on-failure";
         RestartSec = 1;
         TimeoutSec = 5;
-        WorkingDirectory = "${cfg.package}/share/asus-dialpad-driver";
+        WorkingDirectory = "${package}/share/asus-dialpad-driver";
         Environment = [
           "XDG_SESSION_TYPE=${if cfg.wayland then "wayland" else "x11"}"
           "XDG_RUNTIME_DIR=${cfg.runtimeDir}"

--- a/nix/overlay/default.nix
+++ b/nix/overlay/default.nix
@@ -1,0 +1,5 @@
+final: prev: {
+  asus-dialpad-driver = final.callPackage ../default.nix {
+    xinput = prev.xinput or prev.xorg.xinput;
+  };
+}

--- a/nix/overlay/development.nix
+++ b/nix/overlay/development.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  asus-dialpad-driver-shell = final.callPackage ../shell.nix { };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,12 +1,17 @@
-{ stdenv,
-  python3Packages,
+{
   mkShell,
-  self,
+  python3Packages,
+  asus-dialpad-driver,
 }:
+
 mkShell {
-  inputsFrom = [ self.packages.${stdenv.hostPlatform.system}.default ];
+  name = "asus-dialpad-driver";
+
+  inputsFrom = [
+    asus-dialpad-driver
+  ];
   
   packages = [
-        python3Packages.pip
+    python3Packages.pip
   ];
 }

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,21 @@
+let
+  flake_lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+  pkgs-src = builtins.fetchTarball {
+    url = flake_lock.nodes.nixpkgs.locked.url
+      or "https://github.com/NixOS/nixpkgs/archive/${flake_lock.nodes.nixpkgs.locked.rev}.tar.gz";
+    sha256 = flake_lock.nodes.nixpkgs.locked.narHash;
+  };
+
+  pkgs = import pkgs-src {
+    overlays = [
+      (import ./nix/overlay/default.nix)
+      (import ./nix/overlay/development.nix)
+    ];
+  };
+in
+{
+  inherit (pkgs) asus-dialpad-driver;
+  default = pkgs.asus-dialpad-driver;
+  shell = pkgs.asus-dialpad-driver-shell;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./release.nix).shell


### PR DESCRIPTION
I don’t use flakes for my systems (& there’s a number of reasons not to). One issue that happens with the flakes-first approach is designing some coupled systems due to flakes ergonomics (or lack thereof). A couple of big issue popped out immediately:


* `callPackage` was sending along `pkgs`, where just by fallback with `xinput or xorg.xinput` would remove it & the need for this arg & all of `compat.nix`
* `inputs` was an argument to the `module.nix` which couples in the state of inputs now which prevents the module from being composable
* `shell.nix` took `self` to get the `asus-dialpad-driver` package which is coupled to flake state & make the package not really `override`able


What would solve all of these issues is proper deployment of overlays in the system! When using an overlay(s) we can make all the modification in the overlays & let them trickle thru the for users—& with the added bonus that overlays unlock the full power of Nix’s ability to override & patch up packages. I split the overlays into 2: 1) for basic usage 2) for development only; this way development tools don’t pollute a users environment. Both of which can be extended as features might be needed in the future. These overlays were then wired up to power the `flake.nix` while also exposing all the pieces for stable Nix workflows (root-level `release.nix`, `default.nix`, `shell.nix`).

The irony here is that in moving to overlays, you can see the flake now isn’t adding that much value, & arguably it could be simpler now for users to just say `flake = false` in their flake input. For development, now all it gets users is _one_ of the ways to pin inputs 😅.

Aside from this decoupling from experimental Nix features a few other issues have been crossed off:

* file filtering wasn’t happening which would prevent Nix from taking advantage of its cache
* Wayland flag now only overrides the package if set instead of always setting the Wayland flag in the NixOS module
* allow special args to be pass thru the module by adding `...`


& lastly, I touched on the README to show both stable & flake setups.

I tried to make the patchset flow by commit for easy review. Also note that nothing of #33 is addressed, but it this allowed my stable Nix setup to get to same state of that bug.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.