### PR TITLE
NixOS module as user service

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ in
   # Enable Asus DialPad Service
   hardware.asus-dialpad-driver = {
     enable = true;
-    wayland = true; # default
+    sessionTypes = [ "wayland" "x11" ]; # default
     # Enable user-level systemd service
     daemon.enable = true; # default
     layout = "proartp16"; # default

--- a/README.md
+++ b/README.md
@@ -188,13 +188,7 @@ $ bash install_service.sh
 #### NixOS
 
 Nix code is provided for this driver.
-
-> [!IMPORTANT]
-> In case the layout isn't provided, the "proartp16" DialPad layout is used.
-
-> The default value for runtimeDir is `/run/usr/1000/`, for waylandDisplay is `wayland-0` and wayland is `true`.
-
-> Enabling `ignoreWaylandDisplayEnv` removes the explicit declaration of `WAYLAND_DISPLAY` in the service, allowing it to function correctly when switching between desktop environments or window managers that may have different `WAYLAND_DISPLAY` environment variables.
+Please read the `nix/module.nix` for default behavior.
 
 <details>
 <summary>The driver installation (NixOS)</summary>
@@ -224,14 +218,19 @@ in
     (import "${inputs.asus-dialpad-driver}/nix/module.nix")
   ];
 
+  # Users *must* be enrolled in these groups
+  users.users.alice = {
+    extraGroups = [ "i2c" "input" "uinput" ];
+  };
+
   # Enable Asus DialPad Service
-  services.asus-dialpad-driver = {
+  hardware.asus-dialpad-driver = {
     enable = true;
-    layout = "default";
-    wayland = true;
-    ignoreWaylandDisplayEnv = false;
-    runtimeDir = "/run/user/1000/";
-    waylandDisplay = "wayland-0";
+    wayland = true; # default
+    # Enable user-level systemd service
+    daemon.enable = true; # default
+    layout = "proartp16"; # default
+    defaultConfig = { /* … */ };
   };
 }
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770169770,
-        "narHash": "sha256-awR8qIwJxJJiOmcEGgP2KUqYmHG4v/z8XpL9z8FnT1A=",
+        "lastModified": 1778580735,
+        "narHash": "sha256-t+8AVV8ExvOmslz2sLIgw/hJBKlyl65rJvxjvvjHgpE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa290c9891fa4ebe88f8889e59633d20cc06a5f2",
+        "rev": "48d91f2c0ce7b9e589f967d4f685153dd765dcdd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
     pkgsForEach = forAllSystems (system: nixpkgs.legacyPackages.${system}.appendOverlays [
       self.overlays.default
       self.overlays.development
+      self.overlays.check
     ]);
   in {
     packages = forAllSystems (system:
@@ -18,6 +19,8 @@
         default = self.packages.${pkgs.stdenv.hostPlatform.system}.asus-dialpad-driver;
       });
 
+    checks = forAllSystems (system: pkgsForEach.${system}.asus-dialpad-driver-check);
+
     devShells = forAllSystems (system: {
       default = pkgsForEach.${system}.asus-dialpad-driver-shell;
     });
@@ -25,6 +28,7 @@
     overlays = {
       default = import ./nix/overlay/default.nix;
       development = import ./nix/overlay/development.nix;
+      check = import ./nix/overlay/check.nix;
     };
 
     nixosModules.default = import ./nix/module.nix;

--- a/nix/check/module-setup.nix
+++ b/nix/check/module-setup.nix
@@ -44,6 +44,7 @@ testers.nixosTest ({ pkgs, ... }: {
       enable = true;
       daemon.enable = true;
       layout = "proartp16";
+      sessionTypes = [ "wayland" ];
     };
   };
 

--- a/nix/check/module-setup.nix
+++ b/nix/check/module-setup.nix
@@ -1,0 +1,65 @@
+{ testers }:
+
+testers.nixosTest ({ pkgs, ... }: {
+  name = "asus-dialpad-driver-module-basic-setup";
+
+  nodes.machine = { ... }: {
+    imports = [
+      "${pkgs.path}/nixos/tests/common/user-account.nix"
+      ../module.nix
+    ];
+
+    services.getty.autologinUser = "alice";
+
+    environment = {
+      variables = {
+        WLR_RENDERER = "pixman";
+      };
+    };
+
+    users.users.alice = {
+      uid = 1000;
+      name = "alice";
+      description = "Alice Foobar";
+      password = "foobar";
+      isNormalUser = true;
+      extraGroups = [ "i2c" "input" "uinput" ];
+    };
+
+    # Most folks will be using Wayland at this point (despite X11 testing being simpler).
+    # Sway is both popular & lightweight enough to be a good test case.
+    programs.sway.enable = true;
+
+    # Automatically configure & start Sway when logging in on tty1:
+    programs.bash.loginShellInit = /* bash */ ''
+      if [ "$(tty)" = "/dev/tty1" ]; then
+        set -e
+        sway
+      fi
+    '';
+
+    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
+
+    hardware.asus-dialpad-driver = {
+      enable = true;
+      daemon.enable = true;
+      layout = "proartp16";
+    };
+  };
+
+  testScript = { nodes, ... }:
+    let
+      inherit (nodes) machine;
+      inherit (machine.users.users) alice;
+    in
+    /* python */ ''
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+
+      machine.wait_for_file("/run/user/${builtins.toString alice.uid}/wayland-1")
+      machine.wait_for_unit("sway-session.target", "${alice.name}")
+      machine.wait_for_unit("asus-dialpad-driver.service", "${alice.name}")
+
+      assert "uinput" in machine.succeed("udevadm info -e")
+    '';
+})

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -3,11 +3,12 @@
 let
   cfg = config.hardware.asus-dialpad-driver;
 
-  configFileDir = pkgs.writeTextFile {
-    name = "asus-dialpad-driver-config";
-    text = lib.generators.toINI {} cfg.config;
-    destination = "/dialpad_dev";
-  };
+  defaultConfigFile =
+    pkgs.writeText "asus-dialpad-driver-default-config.ini" /* ini */ ''
+      ; vim: filetype=dosini
+      ; Asus DialPad configuration
+      ${lib.generators.toINI { } cfg.defaultConfig}
+    '';
 
   package =
     cfg.package.override
@@ -29,7 +30,10 @@ in {
     daemon.enable = lib.mkOption {
       default = true;
       type = lib.types.bool;
-      description = "Whether to start the Asus DialPad Driver daemon as a systemd user service.";
+      description = ''
+        Whether to start the Asus DialPad Driver daemon as a systemd user service.
+        Note that the user *must* be enrolled in these groups: i2c, input, uinput.
+      '';
     };
 
     package = lib.mkOption {
@@ -50,7 +54,7 @@ in {
       description = "Enable this option to run under Wayland. Disable it for X11.";
     };
 
-    config = lib.mkOption {
+    defaultConfig = lib.mkOption {
       type = with lib.types;
         let
           valueType = nullOr (oneOf [
@@ -75,18 +79,16 @@ in {
           config_supress_app_specifics_shortcuts = 0;
         };
       };
-      default = {};
-      description = "Configuration options for the Asus DialPad Driver.";
+      default = { };
+      description = ''
+        Default configuration options for the Asus DialPad Driver on first run.
+        It’s recommended to use a user-level configuration manager for this file or manually define with `lib.generators.toINI { } { /* your config */ }`.
+      '';
     };
   };
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ package ];
-
-    # Ensure the writable directories exists
-    systemd.tmpfiles.rules = [
-      "d /var/log/asus-dialpad-driver 0755 root root -"
-    ];
 
     # Enable i2c
     hardware.i2c.enable = true;
@@ -97,9 +99,6 @@ in {
       input = { };
       i2c = { };
     };
-
-    # Add root to the necessary groups
-    users.users.root.extraGroups = [ "i2c" "input" "uinput" ];
 
     # Add the udev rule to set permissions for uinput and i2c-dev
     services.udev.extraRules = /* udev */ ''
@@ -112,26 +111,24 @@ in {
     # Load specific kernel modules
     boot.kernelModules = [ "uinput" "i2c-dev" ];
 
-    systemd.services.asus-dialpad-driver = lib.mkIf cfg.daemon.enable {
+    systemd.user.services.asus-dialpad-driver = lib.mkIf cfg.daemon.enable {
       description = "Asus DialPad Driver";
-      wantedBy = [ "default.target" ];
-      startLimitBurst=20;
-      startLimitIntervalSec=300;
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${package}/share/asus-dialpad-driver/dialpad.py ${cfg.layout} ${configFileDir}/";
-        StandardOutput = null;
-        StandardError = null;
+        ConfigurationDirectory = "asus-dialpad-driver";
+        # Create a default config from the Nix config if missing
+        ExecStartPre = "${lib.getExe pkgs.dash} -c 'if [ ! -s %E/asus-dialpad-driver/dialpad_dev ]; then ${lib.getBin pkgs.coreutils}/bin/install -m 644 ${defaultConfigFile} %E/asus-dialpad-driver/dialpad_dev; fi'";
+        ExecStart = "${package}/share/asus-dialpad-driver/dialpad.py ${cfg.layout} %E/asus-dialpad-driver/";
         Restart = "on-failure";
         RestartSec = 1;
         TimeoutSec = 5;
         WorkingDirectory = "${package}/share/asus-dialpad-driver";
         Environment = [
           "XDG_SESSION_TYPE=${if cfg.wayland then "wayland" else "x11"}"
-          "XDG_RUNTIME_DIR=/run/user/1000/"
-          "DISPLAY=:0"
           "LOG=WARNING"
-        ] ++ lib.optional cfg.wayland "WAYLAND_DISPLAY=wayland-0";
+        ];
       };
     };
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  cfg = config.services.asus-dialpad-driver;
+  cfg = config.hardware.asus-dialpad-driver;
 
   configFileDir = pkgs.writeTextFile {
     name = "asus-dialpad-driver-config";
@@ -13,8 +13,24 @@ let
     cfg.package.override
       (lib.optionalAttrs cfg.wayland { waylandSupport = true; });
 in {
-  options.services.asus-dialpad-driver = {
-    enable = lib.mkEnableOption "Enable the Asus DialPad Driver service.";
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "asus-dialpad-driver" ]
+      [ "hardware" "asus-dialpad-driver" ])
+  ];
+
+  options.hardware.asus-dialpad-driver = {
+    enable = lib.mkOption {
+      default = false;
+      type = lib.types.bool;
+      description = "Enable the Asus DialPad Driver module (udev rules, i2c, groups).";
+    };
+
+    daemon.enable = lib.mkOption {
+      default = true;
+      type = lib.types.bool;
+      description = "Whether to start the Asus DialPad Driver daemon as a systemd user service.";
+    };
 
     package = lib.mkOption {
       type = lib.types.package;
@@ -28,35 +44,10 @@ in {
       description = "The layout identifier for the DialPad driver (e.g. proart16). This value is required.";
     };
 
-    display = lib.mkOption {
-      type = lib.types.str;
-      default = ":0";
-      description = "The DISPLAY environment variable. Default is :0.";
-    };
-
     wayland = lib.mkOption {
       type = lib.types.bool;
       default = true;
       description = "Enable this option to run under Wayland. Disable it for X11.";
-    };
-
-    waylandDisplay = lib.mkOption {
-      type = lib.types.str;
-      default = "wayland-0";
-      description = "The WAYLAND_DISPLAY environment variable. Default is wayland-0.";
-    };
-
-    ignoreWaylandDisplayEnv = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description =
-        "If true, WAYLAND_DISPLAY will not be set in the service environment.";
-    };
-
-    runtimeDir = lib.mkOption {
-      type = lib.types.str;
-      default = "/run/user/1000/";
-      description = "The XDG_RUNTIME_DIR environment variable, specifying the runtime directory.";
     };
 
     config = lib.mkOption {
@@ -121,7 +112,7 @@ in {
     # Load specific kernel modules
     boot.kernelModules = [ "uinput" "i2c-dev" ];
 
-    systemd.services.asus-dialpad-driver = {
+    systemd.services.asus-dialpad-driver = lib.mkIf cfg.daemon.enable {
       description = "Asus DialPad Driver";
       wantedBy = [ "default.target" ];
       startLimitBurst=20;
@@ -137,11 +128,10 @@ in {
         WorkingDirectory = "${package}/share/asus-dialpad-driver";
         Environment = [
           "XDG_SESSION_TYPE=${if cfg.wayland then "wayland" else "x11"}"
-          "XDG_RUNTIME_DIR=${cfg.runtimeDir}"
-          "DISPLAY=${cfg.display}"
+          "XDG_RUNTIME_DIR=/run/user/1000/"
+          "DISPLAY=:0"
           "LOG=WARNING"
-        ] ++ lib.optional (!cfg.ignoreWaylandDisplayEnv)
-          "WAYLAND_DISPLAY=${cfg.waylandDisplay}";
+        ] ++ lib.optional cfg.wayland "WAYLAND_DISPLAY=wayland-0";
       };
     };
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -12,7 +12,7 @@ let
 
   package =
     cfg.package.override
-      (lib.optionalAttrs cfg.wayland { waylandSupport = true; });
+      (lib.optionalAttrs (lib.elem "wayland" cfg.sessionTypes) { waylandSupport = true; });
 in {
   imports = [
     (lib.mkRenamedOptionModule
@@ -36,22 +36,21 @@ in {
       '';
     };
 
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.asus-dialpad-driver.override { waylandSupport = cfg.wayland; };
-      description = "The package to use for the Asus DialPad Driver.";
+    package = lib.mkPackageOption pkgs "asus-dialpad-driver" { };
+
+    sessionTypes = lib.mkOption {
+      type = lib.types.uniq (lib.types.nonEmptyListOf (lib.types.enum [ "wayland" "x11" ]));
+      default = [ "wayland" "x11" ];
+      description = ''
+        The display server session types to support.
+        All listed types will be built into the package.
+      '';
     };
 
     layout = lib.mkOption {
       type = lib.types.str;
       default = "proartp16";
       description = "The layout identifier for the DialPad driver (e.g. proart16). This value is required.";
-    };
-
-    wayland = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = "Enable this option to run under Wayland. Disable it for X11.";
     };
 
     defaultConfig = lib.mkOption {
@@ -126,7 +125,6 @@ in {
         TimeoutSec = 5;
         WorkingDirectory = "${package}/share/asus-dialpad-driver";
         Environment = [
-          "XDG_SESSION_TYPE=${if cfg.wayland then "wayland" else "x11"}"
           "LOG=WARNING"
         ];
       };

--- a/nix/overlay/check.nix
+++ b/nix/overlay/check.nix
@@ -1,0 +1,5 @@
+final: prev: {
+  asus-dialpad-driver-check = {
+    module-setup = final.callPackage ../check/module-setup.nix { };
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -1,3 +1,6 @@
+# To make sure everything builds/checks successfull run:
+#
+# 	$ nix-build --no-out-link release.nix
 let
   flake_lock = builtins.fromJSON (builtins.readFile ./flake.lock);
 

--- a/release.nix
+++ b/release.nix
@@ -11,6 +11,7 @@ let
     overlays = [
       (import ./nix/overlay/default.nix)
       (import ./nix/overlay/development.nix)
+      (import ./nix/overlay/check.nix)
     ];
   };
 in
@@ -18,4 +19,5 @@ in
   inherit (pkgs) asus-dialpad-driver;
   default = pkgs.asus-dialpad-driver;
   shell = pkgs.asus-dialpad-driver-shell;
+  check = pkgs.asus-dialpad-driver-check;
 }


### PR DESCRIPTION
This setup I think vastly simplifies the module by just letting the environment do its thing—as well as allowing multiple users to use the module instead of so many hard-coded values. The caveat is that users now need to make sure users are added to the `[ "i2c" "input" "uinput"]` groups or they will run into permission issues. I think this is documented well enough (it’s not fair to do warnings or asserts as some will get permissions not from NixOS config but manual management, LDAP, & so on).

I also added some checks thru `nixosTests` that run a… well I think it’s still a VM. This test isn’t doing _that_ much, but it can assert module assumptions + that, ya know, the service can actually start. If it’s still a VM, hopefully maintainers have KVM enabled so the test actually run pretty fast.

NOTE: I am just now testing this so I can’t 100% confirm that it’s good yet, but I wanted the WIP up so maybe @lavenderdotpet can help me trial run it.

fixes #33 

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.